### PR TITLE
Rename .git-author to .git-author-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git author jh
 # mobbing
 git author jh nn ca
 
-# show who are included in current ~/.git-author
+# show who are included in current ~/.git-author-template
 git author
 ```
 

--- a/git-author
+++ b/git-author
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-git_author_file_name=~/.git-author
+git_author_file_name=~/.git-author-template
 
 print_story_num()
 {

--- a/setup.sh
+++ b/setup.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # create an empty template if it doesn't exist
-touch ~/.git-author
+touch ~/.git-author-template
 
 # config git to use a commit template
-git config --global commit.template ~/.git-author
+git config --global commit.template ~/.git-author-template
 
 # put git-author to search path, so that `git author` works.
 cp git-author /usr/local/bin


### PR DESCRIPTION
This is to address file name confusion rainsed in issue #3, e.g.
~/.git-authors is used by git-duet.

Authored-by: Xin Zhang <xzhang@pivotal.io>