### PR TITLE
Enable global set authors

### DIFF
--- a/git-author
+++ b/git-author
@@ -31,7 +31,7 @@ if [ -n "$1" ] ; then
 		echo ""
 		echo ""
 		print_story_num
-		git-together with "$@" | insert_author_tags $#
+		git-together with --global "$@" | insert_author_tags $#
 	) > "$GIT_AUTHOR_FILE_NAME"
 fi
 


### PR DESCRIPTION
When you get your authors in one git repo, 
Then the authors are set for all git repos